### PR TITLE
JENKINS-38417 Add support for pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,18 @@ This DOES NOT install a Chef client on your Jenkins server, that needs to be don
 The minimum Jenkins version we're building for is LTS 1.554.3.
 Get your bearings with <https://wiki.jenkins-ci.org/display/JENKINS/Plugin+tutorial>
 
+## Pipeline Builds
+To use an Identity in a Pipeline build use the
+[`wrap` step](https://jenkins.io/doc/pipeline/steps/workflow-basic-steps/#code-wrap-code-general-build-wrapper).
+
+```groovy
+node {
+    wrap([$class: 'ChefIdentityBuildWrapper', jobIdentity: 'my-chef']) {
+        sh 'knife node list -c .chef/knife.rb'
+    }
+}
+```
+
 ## TO DO
 * Officially track these on Waffle.io once in Jenkins repo? Or Jenkin's Jira?
 * Localize

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.554.3</version><!-- which version of Jenkins is this plugin built against? Users must have at least this Jenkins version to use this plugin. -->
+    <version>1.609</version><!-- which version of Jenkins is this plugin built against? Users must have at least this Jenkins version to use this plugin. -->
   </parent>
 
   <groupId>org.jenkins-ci.plugins</groupId>
@@ -62,6 +62,14 @@ THE SOFTWARE.
     </repository>
   </repositories>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>matrix-project</artifactId>
+      <version>1.8</version>
+    </dependency>
+  </dependencies>
+
   <pluginRepositories>
     <pluginRepository>
       <id>repo.jenkins-ci.org</id>
@@ -75,4 +83,15 @@ THE SOFTWARE.
     <tag>HEAD</tag>
   </scm>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jenkins-ci.tools</groupId>
+        <artifactId>maven-hpi-plugin</artifactId>
+        <configuration>
+          <compatibleSinceVersion>2.0.0</compatibleSinceVersion>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
Adding basic support for pipelines:
* Make `ChefIdentityBuildWrapper` subclass `SimpleBuildWrapper` so it will work with pipelines
* Add a `SimpleBuildWrapper.Disposer` implemenation to `ChefIdentityCleanup` so the wrapper can cleanup the `.chef` dir
* Document how to use the wrapper in a pipeline in the `README.md`

A couple `pom.xml` changes:
* Change minimum Jenkins version to 1.609, and add dependency on `matrix-plugin` which is not part of the core anymore
* Add `maven-hpi-plugin` so we can generate the `Messages.properties`