### PR TITLE
JENKINS-38417: Build on updated Java to make release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ work/
 .project
 .settings/
 *.sublime*
+.factorypath

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,4 @@
+#!/usr/bin/env groovy
+
+/* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
+buildPlugin()

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@ THE SOFTWARE.
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.609</version><!-- which version of Jenkins is this plugin built against? Users must have at least this Jenkins version to use this plugin. -->
+    <version>3.4</version>
   </parent>
 
   <groupId>org.jenkins-ci.plugins</groupId>
@@ -37,6 +37,11 @@ THE SOFTWARE.
   <name>Chef Identity Plugin</name>
   <description>Allows management of Chef credentials so jobs can execute jobs against a Chef server using those credentials</description>
   <url>http://wiki.jenkins-ci.org/display/JENKINS/chef-identity+plugin</url>
+
+  <properties>
+    <jenkins.version>2.7.3</jenkins.version>
+    <java.level>8</java.level>
+  </properties>
 
   <developers>
     <developer>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <div>
   This plugin manages user credentials for a <a href="http://getchef.com" target="_new">Chef</a> server.
 </div>

--- a/src/main/resources/io/chef/jenkins/ChefIdentityBuildWrapper/config.jelly
+++ b/src/main/resources/io/chef/jenkins/ChefIdentityBuildWrapper/config.jelly
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
+<?jelly escape-by-default='true'?>
  <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <!--
     This jelly script is used for per-project configuration.

--- a/src/main/resources/io/chef/jenkins/ChefIdentityBuildWrapper/global.jelly
+++ b/src/main/resources/io/chef/jenkins/ChefIdentityBuildWrapper/global.jelly
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
+<?jelly escape-by-default='true'?>
  <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <!--
     This Jelly script is used to produce the global configuration option.

--- a/src/main/resources/io/chef/jenkins/ChefIdentityCleanup/config.jelly
+++ b/src/main/resources/io/chef/jenkins/ChefIdentityCleanup/config.jelly
@@ -21,6 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <f:entry title="${%If selected, the .chef folder will be deleted when the build finishes}" />
 </j:jelly>


### PR DESCRIPTION
This is a work in progress.  Adding a `Jenkinsfile` to get it built on the new Jenkins CI server.

But I also know it doesn't build for me locally because of ```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  6.216 s
[INFO] Finished at: 2019-03-10T16:15:15-07:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:2.10.4:javadoc (default) on project chef-identity: Execution default of goal org.apache.maven.plugins:maven-javadoc-plugin:2.10.4:javadoc failed: An API incompatibility was encountered while executing org.apache.maven.plugins:maven-javadoc-plugin:2.10.4:javadoc: java.lang.ExceptionInInitializerError: null
```
The last time I was in this code 3+ years ago it did build.  But Java and Jenkins have moved forward in a way this code hasn't accounted for.

Hopefully I can get an assist from more regular Plugin/Jenkins developers.